### PR TITLE
No longer always writes to memcache

### DIFF
--- a/v1/ds/ds.go
+++ b/v1/ds/ds.go
@@ -137,7 +137,7 @@ func Get(c appengine.Context, key *datastore.Key, dst interface{}) (err error) {
 	if sc.Memcache {
 		err = memcache.Get(c, key, dst)
 		if err == nil {
-			needMemcache = true
+			needMemcache = false
 			goto Complete
 		}
 	}


### PR DESCRIPTION
This line caused the library to always write datastore results to memcache before; this simple change fixes that.
